### PR TITLE
Dependency injection extensions and unit test to ensure correct DI registration of child dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/global.json

--- a/ChatterBot.Core/Auth/DataProtection.cs
+++ b/ChatterBot.Core/Auth/DataProtection.cs
@@ -1,5 +1,4 @@
 ﻿using ChatterBot.Core.Config;
-using Microsoft.Extensions.Options;
 using System;
 using System.Security.Cryptography;
 
@@ -9,9 +8,9 @@ namespace ChatterBot.Core.Auth
     {
         private readonly byte[] _entropy;
 
-        public DataProtection(IOptions<ApplicationSettings> appSettings)
+        public DataProtection(ApplicationSettings appSettings)
         {
-            _entropy = appSettings.Value.SaltBytes;
+            _entropy = appSettings.SaltBytes;
         }
 
         public byte[] Protect(byte[] data)
@@ -20,7 +19,7 @@ namespace ChatterBot.Core.Auth
             {
                 return ProtectedData.Protect(data, _entropy, DataProtectionScope.CurrentUser);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // TODO: Log exception
                 return null;
@@ -33,7 +32,7 @@ namespace ChatterBot.Core.Auth
             {
                 return ProtectedData.Unprotect(data, _entropy, DataProtectionScope.CurrentUser);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // TODO: Log exception
                 return null;

--- a/ChatterBot.Core/DependencyInjection.cs
+++ b/ChatterBot.Core/DependencyInjection.cs
@@ -1,0 +1,14 @@
+﻿using ChatterBot.Core.Auth;
+using ChatterBot.Core.Config;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static void AddCore(this IServiceCollection services, ApplicationSettings appSettings)
+        {
+            services.AddSingleton(new DataProtection(appSettings));
+            services.AddSingleton<TwitchAuthentication>();
+        }
+    }
+}

--- a/ChatterBot.Infra.LiteDb/DataStore.cs
+++ b/ChatterBot.Infra.LiteDb/DataStore.cs
@@ -2,7 +2,6 @@
 using ChatterBot.Core.Config;
 using ChatterBot.Core.Data;
 using LiteDB;
-using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 
 namespace ChatterBot.Infra.LiteDb
@@ -11,11 +10,11 @@ namespace ChatterBot.Infra.LiteDb
     {
         private readonly ApplicationSettings _appSettings;
 
-        public DataStore(IOptions<ApplicationSettings> appSettings)
+        public DataStore(ApplicationSettings appSettings)
         {
-            _appSettings = appSettings.Value;
+            _appSettings = appSettings;
         }
-
+        
         public void EnsureSchema()
         {
             BsonMapper.Global.Entity<TwitchCredentials>().Id(x => x.AuthType);

--- a/ChatterBot.Infra.LiteDb/DependencyInjection.cs
+++ b/ChatterBot.Infra.LiteDb/DependencyInjection.cs
@@ -1,0 +1,19 @@
+﻿using ChatterBot.Core.Config;
+using ChatterBot.Core.Data;
+using ChatterBot.Infra.LiteDb;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static void AddInfrastructureForLiteDb(this IServiceCollection services, ApplicationSettings appSettings)
+        {
+            services.AddSingleton<IDataStore>(provider =>
+            {
+                var dataStore = new DataStore(appSettings);
+                dataStore.EnsureSchema();
+                return dataStore;
+            });
+        }
+    }
+}

--- a/ChatterBot.Infra.Twitch/DependencyInjection.cs
+++ b/ChatterBot.Infra.Twitch/DependencyInjection.cs
@@ -1,0 +1,13 @@
+﻿using ChatterBot.Core.Auth;
+using ChatterBot.Infra.Twitch;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static void AddInfrastructureForTwitch(this IServiceCollection services)
+        {
+            services.AddTransient<ITwitchConnection, TwitchBot>();
+        }
+    }
+}

--- a/ChatterBot.Tests/ChatterBot.Tests.csproj
+++ b/ChatterBot.Tests/ChatterBot.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -8,8 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
   </ItemGroup>
@@ -17,6 +18,12 @@
   <ItemGroup>
     <ProjectReference Include="..\ChatterBot.Core\ChatterBot.Core.csproj" />
     <ProjectReference Include="..\ChatterBot\ChatterBot.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="DependencyInjectionExtensions_UnitTest.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/ChatterBot.Tests/ChatterBot.Tests.csproj
+++ b/ChatterBot.Tests/ChatterBot.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ChatterBot.Tests/DependencyInjectionExtensions_UnitTest.cs
+++ b/ChatterBot.Tests/DependencyInjectionExtensions_UnitTest.cs
@@ -19,7 +19,7 @@ namespace ChatterBot.Tests
             var services = new ServiceCollection();
 
             var fakeAppSettings = new Core.Config.ApplicationSettings() { Entropy = "SomeFakedEntropyString", LightDbConnection = "Filename=database.db;Password=1234" };
-            services.AddUI();
+            //services.AddUI();
             services.AddCore(fakeAppSettings);
             services.AddInfrastructureForLiteDb(fakeAppSettings);
             services.AddInfrastructureForTwitch();

--- a/ChatterBot.Tests/DependencyInjectionExtensions_UnitTest.cs
+++ b/ChatterBot.Tests/DependencyInjectionExtensions_UnitTest.cs
@@ -1,0 +1,61 @@
+﻿#pragma warning disable CA1707 // Identifiers should not contain underscores
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ChatterBot.Tests
+{
+    public class DependencyInjection_Should
+    {
+        [WpfFact]
+        [Trait("Category", "Unit")]
+        public async Task BeAbleToInstantiateAllRegisteredTypes()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            var fakeAppSettings = new Core.Config.ApplicationSettings() { Entropy = "SomeFakedEntropyString", LightDbConnection = "Filename=database.db;Password=1234" };
+            services.AddUI();
+            services.AddCore(fakeAppSettings);
+            services.AddInfrastructureForLiteDb(fakeAppSettings);
+            services.AddInfrastructureForTwitch();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Act
+            var result = new List<object>();
+
+            foreach (var serviceDescriptor in services)
+            {
+                serviceDescriptor.ServiceType.Should().NotBeNull();
+                serviceDescriptor.ServiceType.FullName.Should().NotBeNullOrEmpty();
+
+                try
+                {
+                    // TODO: Fix exceptions for MediatR derived types, for now this will check everything else.
+                    if (serviceDescriptor.ServiceType.FullName.StartsWith("MediatR", StringComparison.InvariantCulture))
+                        continue;
+
+                    var instance = serviceProvider.GetService(serviceDescriptor.ServiceType);
+                    instance.Should().NotBeNull();
+                    instance.Should().BeAssignableTo(serviceDescriptor.ServiceType);
+                    result.Add(instance);
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"Unable to instantiate '{serviceDescriptor.ServiceType.FullName}'", ex);
+                }
+            }
+
+            // Assert
+            var expectedInstanceCountExcludingMediatR = services.Count(x => x.ServiceType.FullName?.StartsWith("MediatR", StringComparison.InvariantCulture) == false);
+            result.Should().HaveCount(expectedInstanceCountExcludingMediatR);
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+}
+#pragma warning restore CA1707 // Identifiers should not contain underscores

--- a/ChatterBot/ChatterBot.csproj
+++ b/ChatterBot/ChatterBot.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="DCLogo.ico" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MahApps.Metro" Version="2.1.1" />
     <PackageReference Include="MahApps.Metro.IconPacks" Version="4.4.0" />
     <PackageReference Include="MediatR" Version="8.1.0" />
@@ -14,12 +18,6 @@
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="DCLogo.ico">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -35,6 +33,14 @@
     <None Update="wwwroot\index.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Resource Include="DCLogo.ico" />
   </ItemGroup>
 
 </Project>

--- a/ChatterBot/DependencyInjection.cs
+++ b/ChatterBot/DependencyInjection.cs
@@ -1,0 +1,26 @@
+﻿using ChatterBot;
+using ChatterBot.Core.Config;
+using ChatterBot.ViewModels;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static void AddUI(this IServiceCollection services)
+        {
+            services.AddSingleton<MainViewModel>();
+            services.AddSingleton<AccountsViewModel>();
+            services.AddSingleton<TerminalViewModel>();
+            services.AddSingleton<AboutViewModel>();
+            services.AddSingleton<CommandsViewModel>();
+            services.AddSingleton<PluginViewModel>();
+            services.AddSingleton<SettingsViewModel>();
+            services.AddTransient<TwitchBotViewModel>();
+            services.AddTransient<TwitchStreamerViewModel>();
+
+            services.AddSingleton<AccountsWindow>();
+            services.AddSingleton<MainWindow>();
+        }
+    }
+}

--- a/ChatterBot/Web/Startup.cs
+++ b/ChatterBot/Web/Startup.cs
@@ -1,6 +1,5 @@
 ﻿using ChatterBot.Core.Auth;
 using ChatterBot.Core.Config;
-using ChatterBot.ViewModels;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
@@ -32,18 +31,7 @@ namespace ChatterBot.Web
             services.AddCore(appSettings);
             services.AddInfrastructureForLiteDb(appSettings);
             services.AddInfrastructureForTwitch();
-
-            services.AddSingleton<MainViewModel>();
-            services.AddSingleton<AccountsViewModel>();
-            services.AddSingleton<TerminalViewModel>();
-            services.AddSingleton<AboutViewModel>();
-            services.AddSingleton<CommandsViewModel>();
-            services.AddSingleton<PluginViewModel>();
-            services.AddSingleton<SettingsViewModel>();
-            services.AddSingleton<AccountsWindow>();
-            services.AddSingleton<MainWindow>();
-            services.AddTransient<TwitchBotViewModel>();
-            services.AddTransient<TwitchStreamerViewModel>();
+            services.AddUI();
         }
 
         public void Configure(IApplicationBuilder app)

--- a/ChatterBot/Web/Startup.cs
+++ b/ChatterBot/Web/Startup.cs
@@ -1,14 +1,11 @@
 ﻿using ChatterBot.Core.Auth;
 using ChatterBot.Core.Config;
-using ChatterBot.Core.Data;
-using ChatterBot.Infra.LiteDb;
 using ChatterBot.ViewModels;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 
 namespace ChatterBot.Web
 {
@@ -33,6 +30,7 @@ namespace ChatterBot.Web
 
             var appSettings = this.Configuration.Get<ApplicationSettings>();
             services.AddCore(appSettings);
+            services.AddInfrastructureForLiteDb(appSettings);
             services.AddInfrastructureForTwitch();
 
             services.AddSingleton<MainViewModel>();
@@ -46,15 +44,6 @@ namespace ChatterBot.Web
             services.AddSingleton<MainWindow>();
             services.AddTransient<TwitchBotViewModel>();
             services.AddTransient<TwitchStreamerViewModel>();
-
-            services.Configure<ApplicationSettings>(Configuration);
-
-            services.AddSingleton<IDataStore>(provider =>
-            {
-                var dataStore = new DataStore(provider.GetService<IOptions<ApplicationSettings>>());
-                dataStore.EnsureSchema();
-                return dataStore;
-            });
         }
 
         public void Configure(IApplicationBuilder app)

--- a/ChatterBot/Web/Startup.cs
+++ b/ChatterBot/Web/Startup.cs
@@ -32,7 +32,8 @@ namespace ChatterBot.Web
 
             services.AddMediatR(typeof(Startup), typeof(AccessTokenRecorder));
 
-            services.AddSingleton<DataProtection>();
+            var appSettings = this.Configuration.Get<ApplicationSettings>();
+            services.AddCore(appSettings);
 
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<AccountsViewModel>();
@@ -43,7 +44,6 @@ namespace ChatterBot.Web
             services.AddSingleton<SettingsViewModel>();
             services.AddSingleton<AccountsWindow>();
             services.AddSingleton<MainWindow>();
-            services.AddSingleton<TwitchAuthentication>();
             services.AddTransient<TwitchBotViewModel>();
             services.AddTransient<TwitchStreamerViewModel>();
             services.AddTransient<ITwitchConnection, TwitchBot>();

--- a/ChatterBot/Web/Startup.cs
+++ b/ChatterBot/Web/Startup.cs
@@ -2,7 +2,6 @@
 using ChatterBot.Core.Config;
 using ChatterBot.Core.Data;
 using ChatterBot.Infra.LiteDb;
-using ChatterBot.Infra.Twitch;
 using ChatterBot.ViewModels;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
@@ -34,6 +33,7 @@ namespace ChatterBot.Web
 
             var appSettings = this.Configuration.Get<ApplicationSettings>();
             services.AddCore(appSettings);
+            services.AddInfrastructureForTwitch();
 
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<AccountsViewModel>();
@@ -46,7 +46,6 @@ namespace ChatterBot.Web
             services.AddSingleton<MainWindow>();
             services.AddTransient<TwitchBotViewModel>();
             services.AddTransient<TwitchStreamerViewModel>();
-            services.AddTransient<ITwitchConnection, TwitchBot>();
 
             services.Configure<ApplicationSettings>(Configuration);
 


### PR DESCRIPTION
### WIP PR for issue #1 
- As it stands, there is currently an issue with the test erroring see below. 
- The PR could be submitted with the unit test set to `Skip="WIP"` so that you would get the benefit of the cleaner organization of the DI extension methods now, with work to resolve the test problem to follow subsequently. 

### Code Changes so far
- [x] @benrick to smoke test that this still runs with a wired-up Twitch API account as I don't have one to hand. 
- [x] Extract Core DI into an extension method.
- [x] Extract Twitch infrastructure DI into an extension method.
- [x] Extract LiteDB infrastructure DI into an extension method.
- [x] Extract Main App DI into an extension method.
- [x] Add unit test to ensure correct DI registration of child dependencies by attempting to instantiate all container registered types.
- [ ] Either set the above unit test to Skip or resolve exception from when attempting to resolve application statice resources for the DataTemplate "MenuItemTemplate".
- [ ] Either resolve issues with MediatR in the above unit test or leave the code as is where it will exclude checking of MediatR types for the time being.

### Changes to dependent packages:
1. Added [FluentAssertions](https://github.com/fluentassertions/fluentassertions) to ChatterBot.Test to improved readability of assertions in tests.

2. Added [Xunit.StaFact](https://github.com/AArnott/Xunit.StaFact) to ChatterBot.Test to resolve an issue with the DI Unit Test:
    - As it was attempting to validate DI registrations for the WPF windows it failed with an exception that they can only be loaded form STA type threads, the new WpfTheory attribute allows for this while not impacting other xunit tests in the same test assembly. 

3. Upgraded xunit from V2.4.0 to V2.4.1 since this is the minimum version required by Xunit.StaFact.

### Unit Test Errors - why this is a draft PR for now:

- Currently having some problems when running the DI Container registration unit test. It is failing because it is unable to resolve the static resources DataTemplate - MenuItemTemplate which is coming from the Application Resources.

- It may be possible to skip the forms in the unit test but given the way its setup with forms being injected into view models this may mean they also have to be skipped which defeats most of the point of the test in the first place. 

- An alternative resolution to this may be to switch from the current DI chain of injecting the forms into the view models and instead inject the ViewModel into the form ctor and set data context there. This would allow the forms and ViewModels to be separated into two DI extension methods and the forms could then be excluded from the dependency validation test. This would however also require MediatR messaging or similar to decouple the ViewModels and forms from having a direct dependency on each other. As it stands it is this strong coupling that is at the heart of the problem. 
