### PR TITLE
#29 introduce interfaces dev

### DIFF
--- a/src/Core/Auth/AccessTokenRecorder.cs
+++ b/src/Core/Auth/AccessTokenRecorder.cs
@@ -8,10 +8,10 @@ namespace ChatterBot.Core.Auth
 {
     public class AccessTokenRecorder : IRequestHandler<AccessTokenReceived, bool>
     {
-        private readonly TwitchAuthentication _twitchAuthentication;
+        private readonly ITwitchAuthentication _twitchAuthentication;
         private readonly IDataProtection _dataProtection;
 
-        public AccessTokenRecorder(TwitchAuthentication twitchAuthentication,
+        public AccessTokenRecorder(ITwitchAuthentication twitchAuthentication,
             IDataProtection dataProtection)
         {
             _twitchAuthentication = twitchAuthentication;

--- a/src/Core/Auth/AccessTokenRecorder.cs
+++ b/src/Core/Auth/AccessTokenRecorder.cs
@@ -9,10 +9,10 @@ namespace ChatterBot.Core.Auth
     public class AccessTokenRecorder : IRequestHandler<AccessTokenReceived, bool>
     {
         private readonly TwitchAuthentication _twitchAuthentication;
-        private readonly DataProtection _dataProtection;
+        private readonly IDataProtection _dataProtection;
 
         public AccessTokenRecorder(TwitchAuthentication twitchAuthentication,
-            DataProtection dataProtection)
+            IDataProtection dataProtection)
         {
             _twitchAuthentication = twitchAuthentication;
             _dataProtection = dataProtection;

--- a/src/Core/Auth/DataProtection.cs
+++ b/src/Core/Auth/DataProtection.cs
@@ -4,7 +4,7 @@ using System.Security.Cryptography;
 
 namespace ChatterBot.Core.Auth
 {
-    public class DataProtection
+    internal class DataProtection : IDataProtection
     {
         private readonly byte[] _entropy;
 

--- a/src/Core/Auth/IDataProtection.cs
+++ b/src/Core/Auth/IDataProtection.cs
@@ -1,0 +1,8 @@
+﻿namespace ChatterBot.Core.Auth
+{
+    public interface IDataProtection
+    {
+        byte[] Protect(byte[] data);
+        byte[] Unprotect(byte[] data);
+    }
+}

--- a/src/Core/Auth/TwitchAuthentication.cs
+++ b/src/Core/Auth/TwitchAuthentication.cs
@@ -12,7 +12,7 @@ namespace ChatterBot.Core.Auth
         Dictionary<AuthenticationType, TwitchCredentials> Credentials { get; set; }
         Dictionary<string, AuthenticationType> States { get; set; }
     }
-    public class TwitchAuthentication : ITwitchAuthentication
+    internal class TwitchAuthentication : ITwitchAuthentication
     {
         public TwitchAuthentication(IDataStore dataStore)
         {

--- a/src/Core/Auth/TwitchAuthentication.cs
+++ b/src/Core/Auth/TwitchAuthentication.cs
@@ -5,7 +5,14 @@ using System.Linq;
 
 namespace ChatterBot.Core.Auth
 {
-    public class TwitchAuthentication
+    public interface ITwitchAuthentication
+    {
+        string GetUrl(AuthenticationType authenticationType);
+
+        Dictionary<AuthenticationType, TwitchCredentials> Credentials { get; set; }
+        Dictionary<string, AuthenticationType> States { get; set; }
+    }
+    public class TwitchAuthentication : ITwitchAuthentication
     {
         public TwitchAuthentication(IDataStore dataStore)
         {

--- a/src/Core/DependencyInjection.cs
+++ b/src/Core/DependencyInjection.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static void AddCore(this IServiceCollection services, ApplicationSettings appSettings)
         {
-            services.AddSingleton(new DataProtection(appSettings));
+            services.AddSingleton<IDataProtection>(new DataProtection(appSettings));
             services.AddSingleton<IPlugin, SimpleCommandsPlugin>();
             services.AddSingleton<CommandsSet>();
             services.AddSingleton<TwitchAuthentication>();

--- a/src/Core/DependencyInjection.cs
+++ b/src/Core/DependencyInjection.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddSingleton<IDataProtection>(new DataProtection(appSettings));
             services.AddSingleton<IPlugin, SimpleCommandsPlugin>();
-            services.AddSingleton<CommandsSet>();
+            services.AddSingleton<ICommandsSet>(new CommandsSet());
             services.AddSingleton<TwitchAuthentication>();
         }
     }

--- a/src/Core/DependencyInjection.cs
+++ b/src/Core/DependencyInjection.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddSingleton<IDataProtection>(new DataProtection(appSettings));
             services.AddSingleton<IPlugin, SimpleCommandsPlugin>();
-            services.AddSingleton<ICommandsSet>(new CommandsSet());
-            services.AddSingleton<TwitchAuthentication>();
+            services.AddSingleton<ICommandsSet, CommandsSet>();
+            services.AddSingleton<ITwitchAuthentication, TwitchAuthentication>();
         }
     }
 }

--- a/src/Core/SimpleCommands/CommandsSet.cs
+++ b/src/Core/SimpleCommands/CommandsSet.cs
@@ -5,7 +5,15 @@ using System.Linq;
 
 namespace ChatterBot.Core.SimpleCommands
 {
-    public class CommandsSet
+    public interface ICommandsSet
+    {
+        BindingList<CustomCommand> CustomCommands { get; }
+
+        IEnumerable<CustomCommand> GetCommandsToRun(ChatMessage chatMessage);
+        void Initialize(List<CustomCommand> commands);
+    }
+
+    internal class CommandsSet : ICommandsSet
     {
         public BindingList<CustomCommand> CustomCommands { get; private set; }
 

--- a/src/Core/SimpleCommands/SimpleCommandsPlugin.cs
+++ b/src/Core/SimpleCommands/SimpleCommandsPlugin.cs
@@ -7,9 +7,9 @@ namespace ChatterBot.Core.SimpleCommands
     internal class SimpleCommandsPlugin : IPlugin
     {
         private readonly IDataStore _dataStore;
-        private readonly CommandsSet _commandsSet;
+        private readonly ICommandsSet _commandsSet;
 
-        public SimpleCommandsPlugin(IDataStore dataStore, CommandsSet commandsSet)
+        public SimpleCommandsPlugin(IDataStore dataStore, ICommandsSet commandsSet)
         {
             _dataStore = dataStore;
             _commandsSet = commandsSet;

--- a/src/Core/SimpleCommands/SimpleCommandsPlugin.cs
+++ b/src/Core/SimpleCommands/SimpleCommandsPlugin.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 
 namespace ChatterBot.Core.SimpleCommands
 {
-    public class SimpleCommandsPlugin : IPlugin
+    internal class SimpleCommandsPlugin : IPlugin
     {
         private readonly IDataStore _dataStore;
         private readonly CommandsSet _commandsSet;

--- a/src/Infra.LiteDb/DataStore.cs
+++ b/src/Infra.LiteDb/DataStore.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace ChatterBot.Infra.LiteDb
 {
-    public class DataStore : IDataStore
+    internal class DataStore : IDataStore
     {
         private readonly ApplicationSettings _appSettings;
 

--- a/src/Infra.Twitch/Extensions/CredentialsExtensions.cs
+++ b/src/Infra.Twitch/Extensions/CredentialsExtensions.cs
@@ -6,6 +6,7 @@ namespace ChatterBot.Infra.Twitch.Extensions
 {
     public static class CredentialsExtensions
     {
+        // TODO: #28 Replace CredentialsExtensions with AutoMapper profiles.
         public static ConnectionCredentials ToTwitchLib(
             this TwitchCredentials credentials, IDataProtection dataProtection)
             => new ConnectionCredentials(credentials.Username,

--- a/src/Infra.Twitch/Extensions/CredentialsExtensions.cs
+++ b/src/Infra.Twitch/Extensions/CredentialsExtensions.cs
@@ -7,7 +7,7 @@ namespace ChatterBot.Infra.Twitch.Extensions
     public static class CredentialsExtensions
     {
         public static ConnectionCredentials ToTwitchLib(
-            this TwitchCredentials credentials, DataProtection dataProtection)
+            this TwitchCredentials credentials, IDataProtection dataProtection)
             => new ConnectionCredentials(credentials.Username,
                 dataProtection.Unprotect(credentials.AuthToken).BytesToString());
     }

--- a/src/Infra.Twitch/Extensions/DomainMappers.cs
+++ b/src/Infra.Twitch/Extensions/DomainMappers.cs
@@ -5,6 +5,7 @@ namespace ChatterBot.Infra.Twitch.Extensions
 {
     public static class DomainMappers
     {
+        // TODO: #28 Replace DomainMappers with AutoMapper profiles.
         public static ChatMessage ToDomain(this TwitchLib.Client.Models.ChatMessage message) =>
             new ChatMessage(DateTime.UtcNow,
                 message.DisplayName, message.ColorHex, message.Message);

--- a/src/Infra.Twitch/TwitchBot.cs
+++ b/src/Infra.Twitch/TwitchBot.cs
@@ -12,9 +12,9 @@ namespace ChatterBot.Infra.Twitch
 {
     internal class TwitchBot : TwitchConnection
     {
-        private readonly CommandsSet _commandsSet;
+        private readonly ICommandsSet _commandsSet;
 
-        public TwitchBot(IDataProtection dataProtection, CommandsSet commandsSet)
+        public TwitchBot(IDataProtection dataProtection, ICommandsSet commandsSet)
             : base(dataProtection)
         {
             _commandsSet = commandsSet;

--- a/src/Infra.Twitch/TwitchBot.cs
+++ b/src/Infra.Twitch/TwitchBot.cs
@@ -10,7 +10,7 @@ using TwitchLib.Client.Events;
 
 namespace ChatterBot.Infra.Twitch
 {
-    public class TwitchBot : TwitchConnection
+    internal class TwitchBot : TwitchConnection
     {
         private readonly CommandsSet _commandsSet;
 

--- a/src/Infra.Twitch/TwitchBot.cs
+++ b/src/Infra.Twitch/TwitchBot.cs
@@ -14,7 +14,7 @@ namespace ChatterBot.Infra.Twitch
     {
         private readonly CommandsSet _commandsSet;
 
-        public TwitchBot(DataProtection dataProtection, CommandsSet commandsSet)
+        public TwitchBot(IDataProtection dataProtection, CommandsSet commandsSet)
             : base(dataProtection)
         {
             _commandsSet = commandsSet;

--- a/src/Infra.Twitch/TwitchConnection.cs
+++ b/src/Infra.Twitch/TwitchConnection.cs
@@ -11,10 +11,10 @@ namespace ChatterBot.Infra.Twitch
 {
     public class TwitchConnection : ITwitchConnection
     {
-        private readonly DataProtection _dataProtection;
+        private readonly IDataProtection _dataProtection;
         protected readonly TwitchClient Client;
 
-        public TwitchConnection(DataProtection dataProtection)
+        public TwitchConnection(IDataProtection dataProtection)
         {
             _dataProtection = dataProtection;
             var clientOptions = new ClientOptions

--- a/src/Infra.Twitch/TwitchConnection.cs
+++ b/src/Infra.Twitch/TwitchConnection.cs
@@ -9,7 +9,7 @@ using TwitchLib.Communication.Models;
 
 namespace ChatterBot.Infra.Twitch
 {
-    public class TwitchConnection : ITwitchConnection
+    internal class TwitchConnection : ITwitchConnection
     {
         private readonly IDataProtection _dataProtection;
         protected readonly TwitchClient Client;

--- a/src/UI/ViewModels/CommandsViewModel.cs
+++ b/src/UI/ViewModels/CommandsViewModel.cs
@@ -7,11 +7,11 @@ namespace ChatterBot.ViewModels
 {
     public class CommandsViewModel : MenuItemViewModel
     {
-        private readonly CommandsSet _commandsSet;
+        private readonly ICommandsSet _commandsSet;
 
         public BindingList<CustomCommand> CustomCommands => _commandsSet.CustomCommands;
 
-        public CommandsViewModel(CommandsSet commandsSet)
+        public CommandsViewModel(ICommandsSet commandsSet)
         {
             _commandsSet = commandsSet;
             Icon = new PackIconFontAwesome { Kind = PackIconFontAwesomeKind.ExclamationSolid };

--- a/src/UI/ViewModels/TwitchAccountViewModel.cs
+++ b/src/UI/ViewModels/TwitchAccountViewModel.cs
@@ -12,10 +12,10 @@ namespace ChatterBot.ViewModels
         private bool _isDisconnected = true;
         private bool _isManualEntry = false;
         private bool _isGeneratedEntry = true;
-        private readonly TwitchAuthentication _twitchAuthentication;
+        private readonly ITwitchAuthentication _twitchAuthentication;
         private readonly ITwitchConnection _twitchConnection;
 
-        protected TwitchAccountViewModel(TwitchAuthentication twitchAuthentication,
+        protected TwitchAccountViewModel(ITwitchAuthentication twitchAuthentication,
             ITwitchConnection twitchConnection,
             AuthenticationType authType)
         {

--- a/src/UI/ViewModels/TwitchBotViewModel.cs
+++ b/src/UI/ViewModels/TwitchBotViewModel.cs
@@ -5,7 +5,7 @@ namespace ChatterBot.ViewModels
 {
     public class TwitchBotViewModel : TwitchAccountViewModel
     {
-        public TwitchBotViewModel(TwitchAuthentication auth, ITwitchConnection twitchConnection)
+        public TwitchBotViewModel(ITwitchAuthentication auth, ITwitchConnection twitchConnection)
             : base(auth, twitchConnection, AuthenticationType.TwitchBot)
         {
             Icon = new PackIconMaterial { Kind = PackIconMaterialKind.Robot };

--- a/src/UI/ViewModels/TwitchStreamerViewModel.cs
+++ b/src/UI/ViewModels/TwitchStreamerViewModel.cs
@@ -5,7 +5,7 @@ namespace ChatterBot.ViewModels
 {
     public class TwitchStreamerViewModel : TwitchAccountViewModel
     {
-        public TwitchStreamerViewModel(TwitchAuthentication auth, ITwitchConnection twitchConnection)
+        public TwitchStreamerViewModel(ITwitchAuthentication auth, ITwitchConnection twitchConnection)
             : base(auth, twitchConnection, AuthenticationType.TwitchStreamer)
         {
             Icon = new PackIconOcticons { Kind = PackIconOcticonsKind.DeviceCameraVideo };

--- a/src/UnitTests/Core/CustomCommandTests/GetCommandsToRun_Should.cs
+++ b/src/UnitTests/Core/CustomCommandTests/GetCommandsToRun_Should.cs
@@ -1,6 +1,8 @@
 ﻿using ChatterBot.Core;
+using ChatterBot.Core.Config;
 using ChatterBot.Core.SimpleCommands;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,12 +12,16 @@ namespace ChatterBot.Tests.Core.CustomCommandTests
 {
     public class GetCommandsToRun_Should
     {
-        private readonly CommandsSet _commandsSet;
+        private readonly ICommandsSet _commandsSet;
         private readonly CustomCommand _customCommand;
 
         public GetCommandsToRun_Should()
         {
-            _commandsSet = new CommandsSet();
+            var fakeAppSettings = new ApplicationSettings() { Entropy = "SomeFakedEntropyString", LightDbConnection = "Filename=database.db;Password=1234" };
+            var services = new ServiceCollection();
+            services.AddCore(fakeAppSettings);
+
+            _commandsSet = services.BuildServiceProvider().GetService<ICommandsSet>();
             _customCommand = new CustomCommand
             {
                 CommandWord = "!ping",


### PR DESCRIPTION
Closes #29 

- All types exposed via DI have been converted to interface implementations by way of 'Extract interface' refactoring.
- The concrete interface implementations are all marked as internal to encourage 'programming to interfaces' and to help stop leaking of implementation details between layers where abstractions should be used. This will also help with third-party types being leaked up into implementation.

The second part of this work will be to implement #31 so that the only reference anything needs are to interfaces and POCOs in Core and then they are handed a concrete implementation by DI. 

However, this does have consideration in regard to the renaming conventions being used. I will add comments to #31 which will need clarification by @benrick before that can be implemented, as it requires either renaming the core project or breaking the unwritten rule that root namespaces match project names and folder structures.

For not though, this PR is a standalone improvement to encapsulation and can be merged in its own right.