### PR TITLE
#34 nullable c# 8

### DIFF
--- a/src/Core/ChatterBot.Domain/ChatterBot.Domain.csproj
+++ b/src/Core/ChatterBot.Domain/ChatterBot.Domain.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <nullable>enable</nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/ChatterBot.Domain/Core/Auth/DataProtection.cs
+++ b/src/Core/ChatterBot.Domain/Core/Auth/DataProtection.cs
@@ -22,7 +22,7 @@ namespace ChatterBot.Core.Auth
             catch (Exception)
             {
                 // TODO: Log exception
-                return null;
+                return Array.Empty<byte>();
             }
         }
 
@@ -35,7 +35,7 @@ namespace ChatterBot.Core.Auth
             catch (Exception)
             {
                 // TODO: Log exception
-                return null;
+                return Array.Empty<byte>();
             }
         }
     }

--- a/src/Core/ChatterBot.Domain/Core/SimpleCommands/CommandsSet.cs
+++ b/src/Core/ChatterBot.Domain/Core/SimpleCommands/CommandsSet.cs
@@ -7,7 +7,7 @@ namespace ChatterBot.Core.SimpleCommands
 {
     internal class CommandsSet : ICommandsSet
     {
-        public BindingList<CustomCommand> CustomCommands { get; private set; }
+        public BindingList<CustomCommand> CustomCommands { get; private set; } = new BindingList<CustomCommand>();
 
         public IEnumerable<CustomCommand> GetCommandsToRun(ChatMessage chatMessage) =>
             CustomCommands

--- a/src/Core/ChatterBot/ChatterBot.csproj
+++ b/src/Core/ChatterBot/ChatterBot.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <nullable>enable</nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/ChatterBot/Core/Auth/AccessTokenReceived.cs
+++ b/src/Core/ChatterBot/Core/Auth/AccessTokenReceived.cs
@@ -4,10 +4,10 @@ namespace ChatterBot.Core.Auth
 {
     public class AccessTokenReceived : IRequest<bool>
     {
-        public string AccessToken { get; set; }
-        public string Scope { get; set; }
-        public string State { get; set; }
-        public string TokenType { get; set; }
+        public string AccessToken { get; set; } = string.Empty;
+        public string Scope { get; set; } = string.Empty;
+        public string State { get; set; } = string.Empty;
+        public string TokenType { get; set; } = string.Empty;
 
         public AccessTokenReceived()
         {

--- a/src/Core/ChatterBot/Core/Auth/AuthenticationType.cs
+++ b/src/Core/ChatterBot/Core/Auth/AuthenticationType.cs
@@ -2,6 +2,7 @@
 {
     public enum AuthenticationType
     {
+        Unknown = 0,
         TwitchBot = 1,
         TwitchStreamer = 2,
     }

--- a/src/Core/ChatterBot/Core/Auth/TwitchCredentials.cs
+++ b/src/Core/ChatterBot/Core/Auth/TwitchCredentials.cs
@@ -1,10 +1,12 @@
-﻿namespace ChatterBot.Core.Auth
+﻿using System;
+
+namespace ChatterBot.Core.Auth
 {
     public class TwitchCredentials
     {
-        public AuthenticationType AuthType { get; set; }
-        public byte[] AuthToken { get; set; }
-        public string Username { get; set; }
-        public string Channel { get; set; }
+        public AuthenticationType AuthType { get; set; } = AuthenticationType.Unknown;
+        public byte[] AuthToken { get; set; } = Array.Empty<byte>();
+        public string Username { get; set; } = string.Empty;
+        public string Channel { get; set; } = string.Empty;
     }
 }

--- a/src/Core/ChatterBot/Core/BaseBindable.cs
+++ b/src/Core/ChatterBot/Core/BaseBindable.cs
@@ -7,14 +7,14 @@ namespace ChatterBot.Core
 {
     public abstract class BaseBindable : INotifyPropertyChanged
     {
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
-        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = "")
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = "")
         {
             if (EqualityComparer<T>.Default.Equals(storage, value)) return false;
 
@@ -23,7 +23,7 @@ namespace ChatterBot.Core
             return true;
         }
 
-        protected bool SetProperty<T>(Func<T> getter, Action<T> setter, T value, [CallerMemberName] string propertyName = null)
+        protected bool SetProperty<T>(Func<T> getter, Action<T> setter, T value, [CallerMemberName] string propertyName = "")
         {
             if (EqualityComparer<T>.Default.Equals(getter(), value)) return false;
 

--- a/src/Core/ChatterBot/Core/Config/ApplicationSettings.cs
+++ b/src/Core/ChatterBot/Core/Config/ApplicationSettings.cs
@@ -4,8 +4,8 @@ namespace ChatterBot.Core.Config
 {
     public class ApplicationSettings
     {
-        public string Entropy { get; set; }
+        public string Entropy { get; set; } = string.Empty;
         public byte[] SaltBytes => Encoding.UTF8.GetBytes(Entropy);
-        public string LightDbConnection { get; set; }
+        public string LightDbConnection { get; set; } = string.Empty;
     }
 }

--- a/src/Core/ChatterBot/Core/Plugin.cs
+++ b/src/Core/ChatterBot/Core/Plugin.cs
@@ -4,9 +4,9 @@ namespace ChatterBot.Core
 {
     public class Plugin : BaseBindable
     {
-        public string Name { get; set; }
-        public string Version { get; set; }
-        public string Location { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Version { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
         public PluginRuntime PluginRuntime { get; set; }
         public bool Enabled { get; set; }
     }

--- a/src/Core/ChatterBot/Core/SimpleCommands/CustomCommand.cs
+++ b/src/Core/ChatterBot/Core/SimpleCommands/CustomCommand.cs
@@ -8,9 +8,9 @@ namespace ChatterBot.Core.SimpleCommands
 
         private string _commandWord = "!";
         private Access _access = Access.Everyone;
-        private string _response;
-        private int _cooldownTime;
-        private int _userCooldownTime;
+        private string _response = string.Empty;
+        private int _cooldownTime = 0;
+        private int _userCooldownTime = 0;
         private bool _enabled = true;
 
         public string CommandWord

--- a/src/Infra/Infra.LiteDb/ChatterBot.Infra.LiteDb.csproj
+++ b/src/Infra/Infra.LiteDb/ChatterBot.Infra.LiteDb.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <nullable>enable</nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Infra/Infra.Twitch/ChatterBot.Infra.Twitch.csproj
+++ b/src/Infra/Infra.Twitch/ChatterBot.Infra.Twitch.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <nullable>enable</nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Infra/Infra.Twitch/Extensions/CredentialsExtensions.cs
+++ b/src/Infra/Infra.Twitch/Extensions/CredentialsExtensions.cs
@@ -7,9 +7,12 @@ namespace ChatterBot.Infra.Twitch.Extensions
     public static class CredentialsExtensions
     {
         // TODO: #28 Replace CredentialsExtensions with AutoMapper profiles.
-        public static ConnectionCredentials ToTwitchLib(
-            this TwitchCredentials credentials, IDataProtection dataProtection)
-            => new ConnectionCredentials(credentials.Username,
-                dataProtection.Unprotect(credentials.AuthToken).BytesToString());
+        public static ConnectionCredentials ToTwitchLib(this TwitchCredentials credentials, IDataProtection dataProtection)
+        {
+            if (credentials.AuthToken == null)
+                throw new System.ArgumentException("Unable to convert null AuthToken", nameof(credentials));
+            
+            return new ConnectionCredentials(credentials.Username, dataProtection.Unprotect(credentials.AuthToken).BytesToString());
+        }
     }
 }

--- a/src/Infra/Infra.Twitch/TwitchBot.cs
+++ b/src/Infra/Infra.Twitch/TwitchBot.cs
@@ -20,14 +20,14 @@ namespace ChatterBot.Infra.Twitch
             _commandsSet = commandsSet;
         }
 
-        protected override void Client_OnJoinedChannel(object sender, OnJoinedChannelArgs e)
+        protected override void Client_OnJoinedChannel(object? sender, OnJoinedChannelArgs e)
         {
             var message = "Hey everyone! I am a bot connected via TwitchLib!";
             Console.WriteLine(message);
             Client.SendMessage(e.Channel, message);
         }
 
-        protected override void Client_OnMessageReceived(object sender, OnMessageReceivedArgs e)
+        protected override void Client_OnMessageReceived(object? sender, OnMessageReceivedArgs e)
         {
             ChatMessage chatMessage = e.ChatMessage.ToDomain();
             IEnumerable<CustomCommand> toRun = _commandsSet.GetCommandsToRun(chatMessage);

--- a/src/Infra/Infra.Twitch/TwitchConnection.cs
+++ b/src/Infra/Infra.Twitch/TwitchConnection.cs
@@ -45,25 +45,25 @@ namespace ChatterBot.Infra.Twitch
             throw new NotImplementedException();
         }
 
-        protected virtual void Client_OnLog(object sender, OnLogArgs e)
+        protected virtual void Client_OnLog(object? sender, OnLogArgs e)
         {
             Console.WriteLine($"{e.DateTime}: {e.BotUsername} - {e.Data}");
         }
 
-        protected virtual void Client_OnConnected(object sender, OnConnectedArgs e)
+        protected virtual void Client_OnConnected(object? sender, OnConnectedArgs e)
         {
             Console.WriteLine($"Connected to {e.AutoJoinChannel}");
         }
 
-        protected virtual void Client_OnJoinedChannel(object sender, OnJoinedChannelArgs e)
+        protected virtual void Client_OnJoinedChannel(object? sender, OnJoinedChannelArgs e)
         {
         }
 
-        protected virtual void Client_OnMessageReceived(object sender, OnMessageReceivedArgs e)
+        protected virtual void Client_OnMessageReceived(object? sender, OnMessageReceivedArgs e)
         {
         }
 
-        protected virtual void Client_OnWhisperReceived(object sender, OnWhisperReceivedArgs e)
+        protected virtual void Client_OnWhisperReceived(object? sender, OnWhisperReceivedArgs e)
         {
         }
     }

--- a/src/Infra/Infra/ChatterBot.Infra.csproj
+++ b/src/Infra/Infra/ChatterBot.Infra.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <nullable>enable</nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/ChatterBot.Tests.csproj
+++ b/src/Tests/ChatterBot.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <nullable>enable</nullable>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Tests/DependencyInjectionExtensions_UnitTest.cs
+++ b/src/Tests/DependencyInjectionExtensions_UnitTest.cs
@@ -31,8 +31,10 @@ namespace ChatterBot.Tests
 
             foreach (var serviceDescriptor in services)
             {
-                serviceDescriptor.ServiceType.Should().NotBeNull();
-                serviceDescriptor.ServiceType.FullName.Should().NotBeNullOrEmpty();
+                if (serviceDescriptor.ServiceType == null)
+                    throw new NullReferenceException("services contains a serviceDescriptor with a null ServiceType");
+                if (serviceDescriptor.ServiceType.FullName == null)
+                    throw new NullReferenceException("services contains a serviceDescriptor with a null ServiceType FullName");
 
                 try
                 {

--- a/src/UI/ChatterBot.UI.csproj
+++ b/src/UI/ChatterBot.UI.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <nullable>enable</nullable>
+    <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <ApplicationIcon></ApplicationIcon>
   </PropertyGroup>

--- a/src/UI/Converters/SelectedItemToContentConverter.cs
+++ b/src/UI/Converters/SelectedItemToContentConverter.cs
@@ -14,7 +14,7 @@ namespace ChatterBot.Converters
             {
                 return values[0] ?? values[1];
             }
-            return null;
+            return null!;
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/src/UI/ViewModels/AccountsViewModel.cs
+++ b/src/UI/ViewModels/AccountsViewModel.cs
@@ -4,7 +4,7 @@ namespace ChatterBot.ViewModels
 {
     public class AccountsViewModel : BaseViewModel
     {
-        private ObservableCollection<TwitchAccountViewModel> _menuItems;
+        private ObservableCollection<TwitchAccountViewModel> _menuItems = new ObservableCollection<TwitchAccountViewModel>();
 
         public AccountsViewModel(TwitchBotViewModel botViewModel, TwitchStreamerViewModel streamerViewModel)
         {

--- a/src/UI/ViewModels/MainViewModel.cs
+++ b/src/UI/ViewModels/MainViewModel.cs
@@ -8,9 +8,9 @@ namespace ChatterBot.ViewModels
 {
     public class MainViewModel : BaseViewModel
     {
-        private ObservableCollection<MenuItemViewModel> _menuItems;
-        private ObservableCollection<MenuItemViewModel> _menuOptionItems;
-        private AccountsWindow _settingsWindow;
+        private ObservableCollection<MenuItemViewModel> _menuItems = new ObservableCollection<MenuItemViewModel>();
+        private ObservableCollection<MenuItemViewModel> _menuOptionItems = new ObservableCollection<MenuItemViewModel>();
+        private AccountsWindow? _settingsWindow; 
         private readonly AccountsViewModel _accountsViewModel;
         private readonly IDataStore _dataStore;
 

--- a/src/UI/ViewModels/MenuItemViewModel.cs
+++ b/src/UI/ViewModels/MenuItemViewModel.cs
@@ -4,24 +4,24 @@ namespace ChatterBot.ViewModels
 {
     public abstract class MenuItemViewModel : BaseViewModel, IHamburgerMenuItemBase
     {
-        private object _icon;
-        private object _label;
-        private object _toolTip;
+        private object? _icon;
+        private object? _label;
+        private object? _toolTip;
         private bool _isVisible = true;
 
-        public object Icon
+        public object? Icon
         {
             get => _icon;
             set => SetProperty(ref _icon, value);
         }
 
-        public object Label
+        public object? Label
         {
             get => _label;
             set => SetProperty(ref _label, value);
         }
 
-        public object ToolTip
+        public object? ToolTip
         {
             get => _toolTip;
             set => SetProperty(ref _toolTip, value);

--- a/src/UI/ViewModels/TerminalViewModel.cs
+++ b/src/UI/ViewModels/TerminalViewModel.cs
@@ -12,7 +12,7 @@ namespace ChatterBot.ViewModels
     {
         public ObservableCollection<ChatMessage> Messages { get; } = new ObservableCollection<ChatMessage>();
 
-        private string _text;
+        private string _text = string.Empty;
         public string Text
         {
             get => _text;
@@ -41,7 +41,7 @@ namespace ChatterBot.ViewModels
             Text = string.Empty;
         }
 
-        private ICommand _sendMessageCommand;
+        private ICommand? _sendMessageCommand;
         public ICommand SendMessageCommand => _sendMessageCommand ??= new ActionCommand(SendMessage);
 
         public ChatMessage Message => new ChatMessage(DateTime.UtcNow,


### PR DESCRIPTION
Closes #34 
Please note this is an initial "surgery with a chainsaw" change to get nullable reference types in place with all the code still compiling and the tests working. 

While I'm certain some of the chosen defaults could be improved, and there should probably be some unit tests added to drive out such scenarios, the intent here is to have this feature enabled sooner rather than later so that the problem doesn't grow worse in the meantime. 