### PR TITLE
#18 Add Fluent Validation

### DIFF
--- a/src/Core/ChatterBot.Domain/ChatterBot.Domain.csproj
+++ b/src/Core/ChatterBot.Domain/ChatterBot.Domain.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="9.1.1" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.6" />

--- a/src/Core/ChatterBot.Domain/DependencyInjection.cs
+++ b/src/Core/ChatterBot.Domain/DependencyInjection.cs
@@ -2,6 +2,7 @@
 using ChatterBot.Core.Config;
 using ChatterBot.Core.Interfaces;
 using ChatterBot.Core.SimpleCommands;
+using ChatterBot.Domain.Validation;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -13,6 +14,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IPlugin, SimpleCommandsPlugin>();
             services.AddSingleton<ICommandsSet, CommandsSet>();
             services.AddSingleton<ITwitchAuthentication, TwitchAuthentication>();
+
+            services.AddTransient<ICustomCommandValidator, CustomCommandValidator>();
         }
     }
 }

--- a/src/Core/ChatterBot.Domain/Validation/CustomCommandValidator.cs
+++ b/src/Core/ChatterBot.Domain/Validation/CustomCommandValidator.cs
@@ -9,13 +9,9 @@ namespace ChatterBot.Domain.Validation
     {
         public CustomCommandValidator()
         {
-            //this.RuleFor(x => x.DecimalFormat)
-            //    .NotEmpty()
-            //    .MaximumLength(Currency.DecimalFormatMaxLength);
-
-            //this.RuleFor(x => x.Symbol)
-            //    .NotEmpty()
-            //    .MaximumLength(Currency.SymbolMaxLength);
+            // TOOD: Add additional validation rules.
+            this.RuleFor(x => x.CommandWord).NotEmpty().WithMessage("{PropertyName} must not be empty.");
+            this.RuleFor(x => x.CommandWord).Must(x => x.StartsWith("!")).WithMessage("{PropertyName} must start with a '!' character.");
         }
     }
 }

--- a/src/Core/ChatterBot.Domain/Validation/CustomCommandValidator.cs
+++ b/src/Core/ChatterBot.Domain/Validation/CustomCommandValidator.cs
@@ -1,0 +1,21 @@
+﻿using ChatterBot.Core.SimpleCommands;
+using FluentValidation;
+
+namespace ChatterBot.Domain.Validation
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Build", "CA1812", Justification = "Compiler dosen't understand dependency injection")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Fluent Validators are never used as collections directly")]
+    internal class CustomCommandValidator : AbstractValidator<CustomCommand>, ICustomCommandValidator
+    {
+        public CustomCommandValidator()
+        {
+            //this.RuleFor(x => x.DecimalFormat)
+            //    .NotEmpty()
+            //    .MaximumLength(Currency.DecimalFormatMaxLength);
+
+            //this.RuleFor(x => x.Symbol)
+            //    .NotEmpty()
+            //    .MaximumLength(Currency.SymbolMaxLength);
+        }
+    }
+}

--- a/src/Core/ChatterBot/ChatterBot.csproj
+++ b/src/Core/ChatterBot/ChatterBot.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="9.1.1" />
     <PackageReference Include="MediatR" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Domain\" />
     <Folder Include="Infra\" />
     <Folder Include="UI\" />
   </ItemGroup>

--- a/src/Core/ChatterBot/Domain/Validation/ICustomCommandValidator.cs
+++ b/src/Core/ChatterBot/Domain/Validation/ICustomCommandValidator.cs
@@ -1,0 +1,9 @@
+﻿using ChatterBot.Core.SimpleCommands;
+using FluentValidation;
+
+namespace ChatterBot.Domain.Validation
+{
+    public interface ICustomCommandValidator : IValidator<CustomCommand>
+    {
+    }
+}

--- a/src/Tests/Domain/Validation/CustomCommandValidator_Should.cs
+++ b/src/Tests/Domain/Validation/CustomCommandValidator_Should.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using ChatterBot.Core.Config;
+using ChatterBot.Core.SimpleCommands;
+using ChatterBot.Domain.Validation;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ChatterBot.Tests.Domain.Validation
+{
+    public class CustomCommandValidator_Should
+    {
+        private readonly ApplicationSettings fakeAppSettings = new ApplicationSettings() { Entropy = "SomeFakedEntropyString", LightDbConnection = "Filename=database.db;Password=1234" };
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        public async Task Return_IsValid_GivenAValidCurrency()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddDomain(this.fakeAppSettings);
+
+            var command = new CustomCommand();
+
+            // Act
+            var result = await services.BuildServiceProvider().GetRequiredService<ICustomCommandValidator>().ValidateAsync(command).ConfigureAwait(false);
+
+            // Assert
+            result.IsValid.Should().BeTrue();
+        }
+    }
+}

--- a/src/Tests/Domain/Validation/CustomCommandValidator_Should.cs
+++ b/src/Tests/Domain/Validation/CustomCommandValidator_Should.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using ChatterBot.Core.Config;
+using ChatterBot.Core.SimpleCommands;
+using ChatterBot.Domain.Validation;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ChatterBot.Tests.Domain.Validation
+{
+    public class CustomCommandValidator_Should
+    {
+        private readonly ApplicationSettings fakeAppSettings = new ApplicationSettings() { Entropy = "SomeFakedEntropyString", LightDbConnection = "Filename=database.db;Password=1234" };
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        public async Task Return_IsValid_GivenAValidCustomCommand()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddDomain(this.fakeAppSettings);
+
+            var command = new CustomCommand();
+
+            // Act
+            var result = await services.BuildServiceProvider().GetRequiredService<ICustomCommandValidator>().ValidateAsync(command).ConfigureAwait(false);
+
+            // Assert
+            result.IsValid.Should().BeTrue();
+        }
+    }
+}

--- a/src/Tests/Domain/Validation/CustomCommandValidator_Should.cs
+++ b/src/Tests/Domain/Validation/CustomCommandValidator_Should.cs
@@ -29,5 +29,42 @@ namespace ChatterBot.Tests.Domain.Validation
             // Assert
             result.IsValid.Should().BeTrue();
         }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        public async Task Return_ValidationError_GivenACustomCommand_WithoutAZeroLengthCommandWord()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddDomain(this.fakeAppSettings);
+
+            var command = new CustomCommand() { CommandWord = string.Empty };
+
+            // Act
+            var result = await services.BuildServiceProvider().GetRequiredService<ICustomCommandValidator>().ValidateAsync(command).ConfigureAwait(false);
+
+            // Assert
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(x => x.Severity == Severity.Error && x.ErrorCode == "NotEmptyValidator" && x.PropertyName == nameof(CustomCommand.CommandWord));
+        }
+
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        public async Task Return_ValidationError_GivenACustomCommand_WithoutACommandWordThatDoseNotStartWithAnExclamation()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddDomain(this.fakeAppSettings);
+
+            var command = new CustomCommand() { CommandWord = "MyCommandWord" };
+
+            // Act
+            var result = await services.BuildServiceProvider().GetRequiredService<ICustomCommandValidator>().ValidateAsync(command).ConfigureAwait(false);
+
+            // Assert
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(x => x.Severity == Severity.Error && x.ErrorCode == "PredicateValidator" && x.PropertyName == nameof(CustomCommand.CommandWord));
+        }
     }
 }

--- a/src/UI/ChatterBot.UI.csproj
+++ b/src/UI/ChatterBot.UI.csproj
@@ -9,6 +9,10 @@
     <ApplicationIcon></ApplicationIcon>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;NETSDK1080</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="DCLogo.ico" />
   </ItemGroup>


### PR DESCRIPTION
### Closes #18 

- Added Fluent validation package
- Added example validator, including custom predicate rule and use of property name replace term in custom messages
- Set-up DI for validator in the Domain.
- Added Unit Tests for the validator

This is not a full validator for CustomCommand. @benrick should create an issue for that defining bullet points for the validation rules to be enforced, then it can be picked back up at a later date. Rather this is intended as a POC to ensure the package is integrated into the codebase correctly.

### Also, because it was annoying me:
An additional commit to removed he compiler warning about ASP.Net core, that was the result of the compiler failing to understand how we are hosting a web server in a WPF desktop app.