### PR TITLE
Fix Project References and Warnings

### DIFF
--- a/src/Plugins/SimpleCommands/SimpleCommands.csproj
+++ b/src/Plugins/SimpleCommands/SimpleCommands.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UseWPF>true</UseWPF>
     <nullable>enable</nullable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>ChatterBot.Plugins.SimpleCommands</RootNamespace>
@@ -14,22 +15,10 @@
     <PackageReference Include="MahApps.Metro.IconPacks" Version="4.4.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Page Include="CommandsView.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Core\ChatterBot.Domain\ChatterBot.Domain.csproj" />
     <ProjectReference Include="..\..\Core\ChatterBot\ChatterBot.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="CommandsView.xaml.cs">
-      <SubType>Code</SubType>
-    </Compile>
   </ItemGroup>
 
 </Project>

--- a/src/UI/ChatterBot.UI.csproj
+++ b/src/UI/ChatterBot.UI.csproj
@@ -18,9 +18,12 @@
     <PackageReference Include="MahApps.Metro.IconPacks" Version="4.4.0" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UI/ChatterBot.UI.csproj
+++ b/src/UI/ChatterBot.UI.csproj
@@ -9,10 +9,6 @@
     <ApplicationIcon></ApplicationIcon>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;NETSDK1080</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="MahApps.Metro" Version="2.1.1" />
     <PackageReference Include="MahApps.Metro.IconPacks" Version="4.4.0" />


### PR DESCRIPTION
Fixes:
- Warning on the `ChatterBot.UI` project regarding having a `PackageReference` to `Microsoft.AspNetCore.App`. Changed it to a `FrameworkReference`.
- Warning on the `SimpleCommands` project, because we didn't indicate that it uses WPF. Referencing WPF, which means we don't need to explicitly compile the `Views` anymore.

I think you'll like this one, @SimonGeering as it removes the warnings.